### PR TITLE
Allow adding domains to an app that does not have domains yet.

### DIFF
--- a/heroku/api.py
+++ b/heroku/api.py
@@ -120,6 +120,7 @@ class HerokuCore(object):
         list_resource = map(items=items)
         list_resource._h = self
         list_resource._obj = obj
+        list_resource._kwargs = kwargs
 
         return list_resource
 

--- a/heroku/structures.py
+++ b/heroku/structures.py
@@ -17,6 +17,7 @@ class KeyedListResource(object):
         self._h = None
         self._items = items or list()
         self._obj = None
+        self._kwargs = {}
 
     def __repr__(self):
         return repr(self._items)
@@ -40,14 +41,17 @@ class KeyedListResource(object):
         return v
 
     def add(self, *args, **kwargs):
+        full_kwargs = {}
+        full_kwargs.update(self._kwargs)
+        full_kwargs.update(kwargs)
 
         try:
-            return self[0].new(*args, **kwargs)
+            return self[0].new(*args, **full_kwargs)
         except IndexError:
             o = self._obj()
             o._h = self._h
 
-            return o.new(*args, **kwargs)
+            return o.new(*args, **full_kwargs)
 
 
     def remove(self, key):


### PR DESCRIPTION
Currently, trying to `cloud.apps[0].domains.add('mydomain.com')` does not work if `cloud.apps[0]` does not have domains yet, as in this case the `app` keyword to `heroku.api.HerokuCore._get_resources` from `heroku.models.App.domains` is lost. This patch stores the keyword arguments passed to `_get_resources` on the `KeyedListResource` and uses it in its `add` method.
