### PR TITLE
Pulled 'transitioned_at' key from Process class.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,4 +11,5 @@ Patches and Suggestions
 ```````````````````````
 
 - johtso <johtso@gmail.com>
+- skoczen <skoczen@gmail.com>
 - You?

--- a/heroku/models.py
+++ b/heroku/models.py
@@ -487,7 +487,7 @@ class Process(BaseResource):
 
     _ints = ['elapsed']
     _bools = ['attached']
-    _dates = ['transitioned_at']
+    _dates = []
     _pks = ['process', 'upid']
 
 


### PR DESCRIPTION
Hey Kenneth,

I've just pulled the 'transitioned_at' key from the class, since the API no longer returns it as part of the `/apps/:app/ps` response, and heroku.py was crashing.

If the API's going to be fixed, feel free to reject this, but I needed it in the meantime for a production site, and thought a pull might be useful!

Cheers,
-Steven
