### PR TITLE
Avoid throwing a KeyError when scaling down to 0 dynos

### DIFF
--- a/heroku/models.py
+++ b/heroku/models.py
@@ -558,7 +558,10 @@ class Process(BaseResource):
 
         r.raise_for_status()
 
-        return self.app.processes[self.type]
+        if self.type in self.app.processes:
+            return self.app.processes[self.type]
+        else:
+            return ProcessListResource()
 
 
 


### PR DESCRIPTION
Hello!

I believe I have a patch for issue #10 - throwing a KeyError when scaling down to 0 workers. Interested?
## 

test case:
1. scale down to 0 dynos if >= 1 currently exist
   
   HEAD branch behaviour:
   
   ```
   - Process is scaled down to zero
   - Trying to return 'self.app.processes[self.type]' throws a KeyError:
   
         File "/app/.heroku/venv/lib/python2.7/site-packages/heroku/structures.py", line 46, in add
           return self[0].new(*args, **kwargs)
         File "/app/.heroku/venv/lib/python2.7/site-packages/heroku/models.py", line 510, in new
           return self.app.processes[type]
         File "/app/.heroku/venv/lib/python2.7/site-packages/heroku/structures.py", line 86, in __getitem__
           raise why
       KeyError: 'web'
   ```
   
   After patch:
       - Process is scaled down to zero
       - An empty ProcessListResource is returned (is that acceptable?)
