### PR TITLE
Logs with tail=True blocks on get request

### DIFF
--- a/heroku/models.py
+++ b/heroku/models.py
@@ -313,7 +313,7 @@ class App(BaseResource):
         )
 
         # Grab the actual logs.
-        r = requests.get(r.content, verify=False)
+        r = requests.get(r.content, verify=False, prefetch=False)
 
         if not tail:
             return r.content


### PR DESCRIPTION
At some point the default parameter for prefetch was changed from False to True in requests. This change was causing logs(tail=True) to never return. This forces prefetch to be False and the logs get call.
