### PR TITLE
Corrected app delete example code.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ Create a new app::
 
 Delete the app completely::
 
-    >>> app.delete()
+    >>> app.destroy()
     True
 
 And much more. Detailed docs forthcoming.


### PR DESCRIPTION
Actual function call is app.delete(). Changed the readme to reflect that.
