### PR TITLE
Add support for configuring an addon when adding it.

### DIFF
--- a/heroku/models.py
+++ b/heroku/models.py
@@ -120,15 +120,16 @@ class Addon(AvailableAddon):
         )
         return r.ok
 
-    def new(self, name):
+    def new(self, name, params=None):
         r = self._h._http_resource(
             method='POST',
-            resource=('apps', self.app.name, 'addons', name)
+            resource=('apps', self.app.name, 'addons', name),
+            params=params
         )
         r.raise_for_status()
         return self.app.addons[name]
 
-    def upgrade(self, name):
+    def upgrade(self, name, params=None):
         """Upgrades an addon to the given tier."""
         # Allow non-namespaced upgrades. (e.g. advanced vs logging:advanced)
         if ':' not in name:
@@ -137,6 +138,7 @@ class Addon(AvailableAddon):
         r = self._h._http_resource(
             method='PUT',
             resource=('apps', self.app.name, 'addons', quote(name)),
+            params=params,
             data=' '   # Server weirdness.
         )
         r.raise_for_status()


### PR DESCRIPTION
Added support for configuring an addon when you are adding it to an application. This feature is present in the ruby wrapper, and is very useful. Tested using the deployhooks addon, as programatically specifying a hook url is useful.

Example usage:

```
cloud = heroku.from_pass("person@awesome.com","magic")
awesome_app = cloud.apps[-1]
awesome_app.addons.add("deployhooks:http",params{'url':'http://awesome.herokuapp.com/depHook'})

```
