### PR TITLE
User account details are now accessible

### DIFF
--- a/heroku/api.py
+++ b/heroku/api.py
@@ -102,7 +102,7 @@ class HerokuCore(object):
                                    (r.status_code, r.content.decode("utf-8")))
             http_error.response = r
             raise http_error
-        
+
         r.raise_for_status()
 
         return r
@@ -142,6 +142,10 @@ class Heroku(HerokuCore):
         return '<heroku-client at 0x%x>' % (id(self))
 
     @property
+    def account(self):
+        return self._get_resource(('account'), Account)
+
+    @property
     def addons(self):
         return self._get_resources(('addons'), Addon)
 
@@ -152,11 +156,11 @@ class Heroku(HerokuCore):
     @property
     def keys(self):
         return self._get_resources(('user', 'keys'), Key, map=SSHKeyListResource)
-    
+
     @property
     def labs(self):
         return self._get_resources(('features'), Feature, map=filtered_key_list_resource_factory(lambda obj: obj.kind == 'user'))
-        
+
 
 
 class ResponseError(ValueError):

--- a/heroku/models.py
+++ b/heroku/models.py
@@ -94,6 +94,17 @@ class BaseResource(object):
         return d
 
 
+class Account(BaseResource):
+
+    _strs = ['email' ,'id']
+    _bools = ['beta', 'verified', 'allow_tracking']
+    _pks = ['id']
+    _dates = ['created_at', 'updated_at', 'last_login']
+
+    def __repr__(self):
+        return "<account '{0}'>".format(self.email)
+
+
 class AvailableAddon(BaseResource):
     """Heroku Addon."""
 


### PR DESCRIPTION
While developing an addon, it become apparent that we are missing the ability obtain the authenticated user's information, so I added it in.

This is purely read-only at the moment, but it serves as a good starting point.

```
>>> import heroku
>>> code = "redacted"
>>> c = heroku.from_key(code)
>>> c.account
<account 'dude@heroku.com'>
>>> c.account.email
u'dude@heroku.com'
>>> c.account.beta
>>> c.account.verified
True
>>> c.account.allow_tracking
True
>>> c.account.id
u'1995845@users.heroku.com'
>>> c.account.created_at
datetime.datetime(2013, 3, 19, 15, 12, 28, tzinfo=tzoffset(None, -25200))
>>> c.account.updated_at
datetime.datetime(2013, 7, 16, 20, 29, 39, tzinfo=tzoffset(None, -25200))
>>> c.account.last_login
datetime.datetime(2013, 7, 16, 20, 29, 39, tzinfo=tzoffset(None, -25200))
```
