### PR TITLE
Now collecting confirmed & confirmed_at

### DIFF
--- a/heroku/models.py
+++ b/heroku/models.py
@@ -97,9 +97,9 @@ class BaseResource(object):
 class Account(BaseResource):
 
     _strs = ['email' ,'id']
-    _bools = ['beta', 'verified', 'allow_tracking']
+    _bools = ['allow_tracking', 'beta', 'confirmed', 'verified']
     _pks = ['id']
-    _dates = ['created_at', 'updated_at', 'last_login']
+    _dates = ['confirmed_at', 'created_at', 'last_login', 'updated_at']
 
     def __repr__(self):
         return "<account '{0}'>".format(self.email)


### PR DESCRIPTION
I was thrown off by testing on V3, then realised that this plugin was for V2. Was wondering why user UUIDs were being coerced into email like addresses.

Also added in confirmed (bool) and confirmed_at (datetime)

:neckbeard: 
