### PR TITLE
Adding iterability to Config Variables Dictionary

### DIFF
--- a/heroku/models.py
+++ b/heroku/models.py
@@ -391,6 +391,12 @@ class ConfigVars(object):
 
         super(ConfigVars, self).__init__()
 
+    def __iter__(self):
+        return self.data.iteritems()
+
+    def __getitem__(self,key):
+        return self.data[key]
+
     def __repr__(self):
         return repr(self.data)
 


### PR DESCRIPTION
Is there any reason not to be able to iterate over the config dictionary and/or retrieve specific items?

> > > app = cloud.apps['sample-app']
> > > conf = app.config
> > > for k, v in conf:
> > >  print k
> > > 
> > > conf['DATABASE_URL']
> > > u'postgres://user:pass@somedb.com/database'

This would add that functionality.  Hope it helps... 
