### PR TITLE
Fallback to add-on name if attachment_name is None

### DIFF
--- a/heroku/models.py
+++ b/heroku/models.py
@@ -132,7 +132,7 @@ class Addon(AvailableAddon):
     def delete(self):
         addon_name = self.name
         try:
-            addon_name = self.attachment_name
+            addon_name = self.attachment_name or addon_name
         except:
             pass
         r = self._h._http_resource(


### PR DESCRIPTION
When trying to remove the SSL add-on from one of my apps, the library used `None` as add-on name. That's because rather than sticking to `self.name`, the code replaces it with `self.attachment_name`, which is `None` in this particular case. My change defaults to `self.name` in case `self.attachment_name` is `None`
