### PR TITLE
Allow client to provide region for new app

### DIFF
--- a/heroku/models.py
+++ b/heroku/models.py
@@ -180,7 +180,7 @@ class App(BaseResource):
     def __repr__(self):
         return "<app '{0}'>".format(self.name)
 
-    def new(self, name=None, stack='cedar'):
+    def new(self, name=None, stack='cedar', region=None):
         """Creates a new app."""
 
         payload = {}
@@ -190,6 +190,9 @@ class App(BaseResource):
 
         if stack:
             payload['app[stack]'] = stack
+
+        if region:
+            payload['app[region]'] = region
 
         r = self._h._http_resource(
             method='POST',

--- a/heroku/models.py
+++ b/heroku/models.py
@@ -538,7 +538,7 @@ class Process(BaseResource):
         )
 
         r.raise_for_status()
-        return self.app.processes[r.json['process']]
+        return self.app.processes[r.json()['process']]
 
     @property
     def type(self):


### PR DESCRIPTION
Currently the library doesn't allow the client to specify the region for a new app.
This patch addresses it.